### PR TITLE
Add timezone and date fields to FlightSchedule types

### DIFF
--- a/src/api/misc/aviationstack-contract.ts
+++ b/src/api/misc/aviationstack-contract.ts
@@ -161,6 +161,8 @@ const FlightScheduleLocationZ = z.object({
   icaoCode: z.string().describe("The ICAO code of the departure/arrival airport. Example: KJFK, KLAX"),
   scheduledTime: z.string().describe("The scheduled departure/arrival time"),
   terminal: z.string().nullable().describe("The departure/arrival terminal"),
+  timezone: z.string().optional().describe("The timezone of the departure/arrival airport"),
+  date: z.string().optional().describe("The date of departure/arrival in YYYY-MM-DD format"),
 });
 
 const FlightScheduleAirlineZ = z.object({
@@ -188,6 +190,7 @@ const FlightScheduleZ = z.object({
   flight: FlightScheduleFlightZ.describe("The flight information including numbers and codes"),
   status: z.string().describe("The current status of the flight. Possible values: scheduled, active, landed, cancelled, incident, diverted"),
   type: z.enum(["departure", "arrival"]).describe("The type of flight schedule (departure or arrival)"),
+  flightDate: z.string().optional().describe("The date of the flight in YYYY-MM-DD format"),
 });
 
 const GetFlightSchedulesResponseZ = z.object({


### PR DESCRIPTION
## Summary

This PR extends the FlightSchedule type definitions to support timezone offset calculations in the UI.

### Changes

- Added `timezone` field (optional) to `FlightScheduleLocationZ` for departure/arrival timezone information
- Added `date` field (optional) to `FlightScheduleLocationZ` for explicit departure/arrival dates  
- Added `flightDate` field (optional) to `FlightScheduleZ` for the overall flight date

These fields enable the main application to accurately calculate and display timezone offsets, showing users when flights arrive on a different calendar day than departure due to timezone differences.

### Impact

This change is backward compatible as all new fields are optional. Existing code will continue to work without modification.

### Related PRs

- Main application PR: https://github.com/first-to-fly/firsttofly-travel-web/pull/892
- Fixes: https://github.com/first-to-fly/firsttofly-travel-web/issues/890

🤖 Generated with [Claude Code](https://claude.com/claude-code)